### PR TITLE
support for loading playlists with numeric keys

### DIFF
--- a/mopidy_IRControl/__init__.py
+++ b/mopidy_IRControl/__init__.py
@@ -30,6 +30,7 @@ class Extension(ext.Extension):
         schema['menu'] = config.String()
         schema['favorites'] = config.String()
         schema['search'] = config.String()
+        schema['playlist_uri_template'] = config.String()
         schema['num0'] = config.String()
         schema['num1'] = config.String()
         schema['num2'] = config.String()

--- a/mopidy_IRControl/ext.conf
+++ b/mopidy_IRControl/ext.conf
@@ -8,11 +8,7 @@ playpause = KEY_PLAYPAUSE
 stop = KEY_STOP
 volumeup = KEY_VOLUMEUP
 volumedown = KEY_VOLUMEDOWN
-# The following are not used yet.
-power = KEY_POWER
-menu = KEY_MENU
-favorites = KEY_FAVORITES
-search = KEY_SEARCH
+playlist_uri_template = m3u:playlist{0}.m3u
 num0 = KEY_0
 num1 = KEY_1
 num2 = KEY_2
@@ -23,4 +19,8 @@ num6 = KEY_6
 num7 = KEY_7
 num8 = KEY_8
 num9 = KEY_9
-
+# The following are not used yet.
+power = KEY_POWER
+menu = KEY_MENU
+favorites = KEY_FAVORITES
+search = KEY_SEARCH


### PR DESCRIPTION
Hi,
I would like to add support for the loading of playlists with numeric keys to your extension.
The idea is simple: every key's number will be substituted into the `playlist_uri_template` config parameter and the playlist with the resulting `uri` will be loaded.
I added some tests as well.

Thanks!