### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@
 Mopidy-IRControl
 ****************************
 
-.. image:: https://pypip.in/v/Mopidy-IRControl/badge.png
+.. image:: https://img.shields.io/pypi/v/Mopidy-IRControl.svg
     :target: https://pypi.python.org/pypi/Mopidy-IRControl/
     :alt: Latest PyPI version
 
-.. image:: https://pypip.in/d/Mopidy-IRControl/badge.png
+.. image:: https://img.shields.io/pypi/dm/Mopidy-IRControl.svg
     :target: https://pypi.python.org/pypi/Mopidy-IRControl/
     :alt: Number of PyPI downloads
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20mopidy-ircontrol))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `mopidy-ircontrol`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.